### PR TITLE
Refactor card implementation and add MyUWCardContent component

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,59 +12,55 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto:300, 400&display=swap" rel="stylesheet">
 <script type="module" src="dist/myuw-card.mjs"></script>
 <div class="demo__container">
-  <myuw-card-frame size="full">
-    <myuw-card-header
-      slot="myuw-card-header"
-      title="Icon Link"
-    ></myuw-card-header>
-    <myuw-icon-link
-      icon="face"
-      icon-type="md"
-      href="https://www.google.com"
-    ></myuw-icon-link>
-    <myuw-card-footer
-      slot="myuw-card-footer"
-      text="Launch app"
-      href="https://www.google.com"
-    ></myuw-card-footer>
+  <myuw-card-frame>
+    <myuw-card-header>
+      Icon Link
+    </myuw-card-header>
+    <myuw-card-content>
+      <myuw-icon-link
+        icon="face"
+        icon-type="md"
+        href="https://www.google.com"
+      ></myuw-icon-link>
+    </myuw-card-content>
+    <myuw-card-footer href="https://www.google.com">
+      Launch app
+    </myuw-card-footer>
   </myuw-card-frame>
-  <myuw-card-frame size="full">
-    <myuw-card-header
-      slot="myuw-card-header"
-      title="Icon Link and Message"
-    ></myuw-card-header>
-    <myuw-card-message
-      message="You've got mail!"
-    ></myuw-card-message>
-    <myuw-icon-link
-      icon="fa-bookmark-o"
-      icon-type="fa"
-      href="https://www.google.com"
-    ></myuw-icon-link>
-    <myuw-card-footer
-      slot="myuw-card-footer"
-      text="Launch app"
-      href="https://www.google.com"
-    ></myuw-card-footer>
+  <myuw-card-frame>
+    <myuw-card-header>
+      Icon Link and Message
+    </myuw-card-header>
+    <myuw-card-content>
+      <myuw-card-message>
+        You've got mail!
+      </myuw-card-message>
+      <myuw-icon-link
+        icon="fa-bookmark-o"
+        icon-type="fa"
+        href="https://www.google.com"
+      ></myuw-icon-link>
+    </myuw-card-content>
+    <myuw-card-footer href="https://www.google.com">
+      Launch app
+    </myuw-card-footer>
   </myuw-card-frame>
-  <myuw-card-frame size="full">
-    <myuw-card-header
-      slot="myuw-card-header"
-      title="Icon Link and Warn Message"
-    ></myuw-card-header>
-    <myuw-card-message
-      message="Time to wake up!"
-      variant="warn"
-    ></myuw-card-message>
-    <myuw-icon-link
-      icon="alarm"
-      icon-type="md"
-      href="https://www.google.com"
-    ></myuw-icon-link>
-    <myuw-card-footer
-      slot="myuw-card-footer"
-      text="Launch app"
-      href="https://www.google.com"
-    ></myuw-card-footer>
+  <myuw-card-frame>
+    <myuw-card-header>
+      Icon Link and Warn Message
+    </myuw-card-header>
+    <myuw-card-content>
+      <myuw-card-message variant="warn">
+        Time to wake up!
+      </myuw-card-message>
+      <myuw-icon-link
+        icon="alarm"
+        icon-type="md"
+        href="https://www.google.com"
+      ></myuw-icon-link>
+    </myuw-card-content>
+    <myuw-card-footer href="https://www.google.com">
+      Lanch app
+    </myuw-card-footer>
   </myuw-card-frame>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "myuw-card",
+  "name": "@myuw-web-components/myuw-card",
   "version": "2.0.0",
   "description": "",
   "module": "dist/myuw-card.min.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@myuw-web-components/myuw-card",
-  "version": "1.3.1",
+  "name": "myuw-card",
+  "version": "2.0.0",
   "description": "",
   "module": "dist/myuw-card.min.mjs",
   "browser": "dist/myuw-card.js",

--- a/src/content/myuw-card-message.js
+++ b/src/content/myuw-card-message.js
@@ -8,15 +8,16 @@ export class MyUWCardMessage extends HTMLElement {
       this._template = document.createElement("template");
       this._template.innerHTML = `
         <style>
-          #message {
+          :host {
             font-weight: lighter;
             font-size: 14px;
+            text-align: center;
           }
           .warn {
             color: #c5050c;
           }
         </style>
-        <p id="message"></p>
+        <p id="message"><slot></slot></p>
       `;
     }
     return this._template;
@@ -29,12 +30,7 @@ export class MyUWCardMessage extends HTMLElement {
       MyUWCardMessage.template.content.cloneNode(true)
     );
     const node = this.shadowRoot.getElementById("message");
-    node.innerText = this.message;
     node.className = this.variant;
-  }
-
-  get message() {
-    return this.getAttribute("message") || "";
   }
 
   get variant() {

--- a/src/content/myuw-icon-link.js
+++ b/src/content/myuw-icon-link.js
@@ -10,16 +10,30 @@ export class MyUWIconLink extends HTMLElement {
       this._template = document.createElement("template");
       this._template.innerHTML = `
         <style>
+          :host {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            max-height: 100%;
+            justify-content: center;
+            align-items: center;
+          }
           a {
+            display: flex;
+            flex: 1;
+            width: 100%;
             text-decoration: none;
             color: #333;
           }
           #container {
             display: flex;
-            flex-grow: 1;
             justify-content: center;
             align-items: center;
-            overflow: hidden;
+            flex-grow: 1;
+          }
+          i {
+            position: relative;
+            top: -10%;
           }
           .material-icons {
             font-family: "Material Icons" !important;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import { MyUWCardContent } from "./myuw-card-content";
 import { MyUWCardFooter } from "./myuw-card-footer";
 import { MyUWCardHeader } from "./myuw-card-header";
 import { MyUWCardFrame } from "./myuw-card-frame";
@@ -5,6 +6,7 @@ import { MyUWCardMessage } from "./content/myuw-card-message";
 import { MyUWIconLink } from "./content/myuw-icon-link";
 
 export {
+  MyUWCardContent,
   MyUWCardFooter,
   MyUWCardHeader,
   MyUWCardFrame,

--- a/src/myuw-card-content.js
+++ b/src/myuw-card-content.js
@@ -1,0 +1,35 @@
+export class MyUWCardContent extends HTMLElement {
+  static get elementName() {
+    return "myuw-card-content";
+  }
+
+  static get template() {
+    if (this._template === undefined) {
+      this._template = document.createElement("template");
+      this._template.innerHTML = `
+        <style>
+          :host {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            background-color: white;
+            width: 100%;
+          }
+        </style>
+        <slot></slot>
+      `;
+    }
+
+    return this._template;
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot.appendChild(
+      MyUWCardContent.template.content.cloneNode(true)
+    );
+  }
+}
+
+window.customElements.define(MyUWCardContent.elementName, MyUWCardContent);

--- a/src/myuw-card-footer.js
+++ b/src/myuw-card-footer.js
@@ -8,35 +8,39 @@ export class MyUWCardFooter extends HTMLElement {
       this._template = document.createElement("template");
       this._template.innerHTML = `
         <style>
-          #footer-button {
-            font-weight: 300;
-            position: absolute;
-            bottom: 0;
-            margin: 0;
-            color: var(--myuw-footer-text, #696969);
-            background: var(--myuw-footer-background, #d8d8d8);
+          :host {
             width: 100%;
-            padding: 8px 0;
-            text-align: center;
+            height: 36px;
+            position: relative;
             font-size: 14px;
-            transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+          }
+          a {
+            color: #696969;
             text-decoration: none;
+            font-family: "Roboto", sans-serif;
+            font-family: var(--myuw-app-bar-font);
+            font-weight: 400;
           }
-          #footer-button:hover {
-            background: var(--myuw-footer-background-hover, var(--myuw-primary-bg, #c5050c));
-            color: var(--myuw-footer-text-hover, #f5f5f5)
+          div {
+            transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+            background-color: #d8d8d8;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 100%;
+            height: 100%;
           }
-          .container {
-            height: 60px;
+          div:hover {
+            background-color: var(--myuw-primary-bg, #c5050c);
+            color: var(--myuw-primary-color, #fafafa);
           }
         </style>
-        <div class="container">
-          <a href="#" id="footer-button" target="_blank" rel="noopener noreferrer">
-            <div>
-              <span id="footer-text"></span>
-            </div>
-          </a>
-        </div>
+
+        <a id="footer-button" href="#">
+          <div>
+            <slot></slot>
+          </div>
+        </a>
       `;
     }
     return this._template;
@@ -49,15 +53,10 @@ export class MyUWCardFooter extends HTMLElement {
       MyUWCardFooter.template.content.cloneNode(true)
     );
     this.shadowRoot.getElementById("footer-button").href = this.href;
-    this.shadowRoot.getElementById("footer-text").innerText = this.text;
   }
 
   get href() {
     return this.getAttribute("href") || "#";
-  }
-
-  get text() {
-    return this.getAttribute("text") || "";
   }
 }
 

--- a/src/myuw-card-frame.js
+++ b/src/myuw-card-frame.js
@@ -8,40 +8,23 @@ export class MyUWCardFrame extends HTMLElement {
       this._template = document.createElement("template");
       this._template.innerHTML = `
         <style>
-          .myuw-card-frame {
+          :host {
+            position: relative;
             display: flex;
             flex-direction: column;
-            position: relative;
-            background: var(--myuw-card-background, #f5f5f5);
-            border-radius: var(--myuw-card-frame-border-radius, 3px);
-            font-family: 'Roboto', sans-serif;
+            border-radius: var(--my-card-frame-border-radius, 3px);
+            font-family: "Roboto", sans-serif;
             color: var(--myuw-card-font-color, #333);
-            height: 290px;
-            width: 290px;
             box-sizing: border-box;
             -webkit-box-direction: normal;
             overflow: hidden;
-            box-shadow: 0 1px 3px 0 rgba(0,0,0,.2),0 1px 1px 0 rgba(0,0,0,.14),0 2px 1px -1px rgba(0,0,0,.12);
-          }
-          .card-content {
-            display: flex;
-            flex-direction: column;
-            justify-content: space-around;
-            align-items: center;
-            width: 100%;
-            height: 100%;
-            position: absolute;
-            padding: 60px 16px;
-            box-sizing: border-box;
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12);
+            width: 290px;
+            height: 290px;
           }
         </style>
-        <div class="myuw-card-frame">
-          <slot name="myuw-card-header"></slot>
-          <div class="card-content">
-            <slot></slot>
-          </div>
-          <slot name="myuw-card-footer"></slot>
-        </div>
+
+        <slot></slot>
       `;
     }
     return this._template;
@@ -51,10 +34,6 @@ export class MyUWCardFrame extends HTMLElement {
     super();
     this.attachShadow({ mode: "open" });
     this.shadowRoot.appendChild(MyUWCardFrame.template.content.cloneNode(true));
-  }
-
-  get size() {
-    return this.getAttribute("size") || "full";
   }
 }
 

--- a/src/myuw-card-header.js
+++ b/src/myuw-card-header.js
@@ -18,7 +18,7 @@ export class MyUWCardHeader extends HTMLElement {
             color: var(--myuw-car-font-color, #333);
             font-weight: 200;
           }
-          svg {
+          .more-icon {
             position: absolute;
             top: 5%;
             right: 5%;
@@ -27,7 +27,7 @@ export class MyUWCardHeader extends HTMLElement {
         </style>
 
         <slot></slot>
-        <svg id="more-icon" width="20" height="20">
+        <svg class="more-icon" width="20" height="20">
           <g transform="scale(0.8)">
               <path d="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z" />
           </g>

--- a/src/myuw-card-header.js
+++ b/src/myuw-card-header.js
@@ -8,44 +8,30 @@ export class MyUWCardHeader extends HTMLElement {
       this._template = document.createElement("template");
       this._template.innerHTML = `
         <style>
-          #myuw-card-header {
-            display: flex;
-            flex-direction: row;
-            font-weight: 300;
+          :host {
+            background-color: white;
+            width: 100%;
             height: 60px;
-            width: 290px;
-            line-height: 1.1;
+            display: flex;
+            justify-content: center;
             align-items: center;
-            padding: 0 40px;
-            -webkit-box-orient: horizontal;
-            -webkit-box-direction: normal;
-            box-sizing: border-box;
+            color: var(--myuw-car-font-color, #333);
+            font-weight: 200;
+          }
+          svg {
             position: absolute;
-            overflow-x: hidden;
-          }
-          #header-text {
-            margin: 0 auto;
-          }
-          #more-icon {
-            position: absolute;
-            top: 0;
-            right: 0;
-            margin: 15px 15px;
-          }
-          path {
-            fill: var(--icon-fill-color, #696969);
+            top: 5%;
+            right: 5%;
+            fill: rgba(0, 0, 0, 0.54);
           }
         </style>
-        <div>
-          <div id="myuw-card-header">
-            <span id="header-text"></span>
-          </div>
-          <svg id="more-icon" width="20" height="20">
-            <g transform="scale(0.8)">
+
+        <slot></slot>
+        <svg id="more-icon" width="20" height="20">
+          <g transform="scale(0.8)">
               <path d="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z" />
-            </g>
-          </svg>
-        <div>
+          </g>
+        </svg>
       `;
     }
     return this._template;
@@ -57,11 +43,6 @@ export class MyUWCardHeader extends HTMLElement {
     this.shadowRoot.appendChild(
       MyUWCardHeader.template.content.cloneNode(true)
     );
-    this.shadowRoot.getElementById("header-text").innerText = this.title;
-  }
-
-  get title() {
-    return this.getAttribute("title") || "";
   }
 }
 


### PR DESCRIPTION
This PR does some significant refactoring of the MyUWCard component to (hopefully) help make new content types easier to add. It also adds a MyUWCardContent component to hold the content components, and changes the API of several of the components to more closely reflect the semantics of standard HTML elements. For example:

```html
<myuw-card-header
  slot="myuw-card-header"
  title="Icon Link"
></myuw-card-header>
```

Has become:

```html
<myuw-card-header>
  Icon Link
</myuw-card-header>
```

The MyUWCardHeader, MyUWCardFooter and MyUWCardMessage components all follow this pattern.