### PR TITLE
Include Font Awesome and Material Icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
   body {
     background: #cccccc;
   }
+
   .demo__container {
     display: grid;
     grid-template-columns: repeat(auto-fit, 290px);
@@ -13,58 +14,20 @@
 <script type="module" src="dist/myuw-card.mjs"></script>
 <div class="demo__container">
   <myuw-card-frame size="full">
-    <myuw-card-header
-      slot="myuw-card-header"
-      title="Icon Link"
-    ></myuw-card-header>
-    <myuw-icon-link
-      icon="face"
-      icon-type="md"
-      href="https://www.google.com"
-    ></myuw-icon-link>
-    <myuw-card-footer
-      slot="myuw-card-footer"
-      text="Launch app"
-      href="https://www.google.com"
-    ></myuw-card-footer>
+    <myuw-card-header slot="myuw-card-header" title="Icon Link"></myuw-card-header>
+    <myuw-icon-link icon="face" icon-type="md" href="https://www.google.com"></myuw-icon-link>
+    <myuw-card-footer slot="myuw-card-footer" text="Launch app" href="https://www.google.com"></myuw-card-footer>
   </myuw-card-frame>
   <myuw-card-frame size="full">
-    <myuw-card-header
-      slot="myuw-card-header"
-      title="Icon Link and Message"
-    ></myuw-card-header>
-    <myuw-card-message
-      message="You've got mail!"
-    ></myuw-card-message>
-    <myuw-icon-link
-      icon="fa-bookmark-o"
-      icon-type="fa"
-      href="https://www.google.com"
-    ></myuw-icon-link>
-    <myuw-card-footer
-      slot="myuw-card-footer"
-      text="Launch app"
-      href="https://www.google.com"
-    ></myuw-card-footer>
+    <myuw-card-header slot="myuw-card-header" title="Icon Link and Message"></myuw-card-header>
+    <myuw-card-message message="You've got mail!"></myuw-card-message>
+    <myuw-icon-link icon="far fa-bookmark" icon-type="fa" href="https://www.google.com"></myuw-icon-link>
+    <myuw-card-footer slot="myuw-card-footer" text="Launch app" href="https://www.google.com"></myuw-card-footer>
   </myuw-card-frame>
   <myuw-card-frame size="full">
-    <myuw-card-header
-      slot="myuw-card-header"
-      title="Icon Link and Warn Message"
-    ></myuw-card-header>
-    <myuw-card-message
-      message="Time to wake up!"
-      variant="warn"
-    ></myuw-card-message>
-    <myuw-icon-link
-      icon="alarm"
-      icon-type="md"
-      href="https://www.google.com"
-    ></myuw-icon-link>
-    <myuw-card-footer
-      slot="myuw-card-footer"
-      text="Launch app"
-      href="https://www.google.com"
-    ></myuw-card-footer>
+    <myuw-card-header slot="myuw-card-header" title="Icon Link and Warn Message"></myuw-card-header>
+    <myuw-card-message message="Time to wake up!" variant="warn"></myuw-card-message>
+    <myuw-icon-link icon="alarm" icon-type="md" href="https://www.google.com"></myuw-icon-link>
+    <myuw-card-footer slot="myuw-card-footer" text="Launch app" href="https://www.google.com"></myuw-card-footer>
   </myuw-card-frame>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-card",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-card",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "module": "dist/myuw-card.min.mjs",
   "browser": "dist/myuw-card.js",

--- a/src/content/myuw-icon-link.js
+++ b/src/content/myuw-icon-link.js
@@ -6,9 +6,9 @@ export class MyUWIconLink extends HTMLElement {
   }
 
   static get template() {
-    if (this._template === undefined) {
-      this._template = document.createElement("template");
-      this._template.innerHTML = `
+    if (this._template===undefined) {
+      this._template=document.createElement("template");
+      this._template.innerHTML=`
         <style>
           a {
             text-decoration: none;
@@ -24,7 +24,7 @@ export class MyUWIconLink extends HTMLElement {
           .material-icons {
             font-family: "Material Icons" !important;
           }
-          .material-icons.md-70, .fa.fa-70 {
+          .material-icons.md-70, .fa-70 {
             font-size: 70px;
           }
         </style>
@@ -44,19 +44,19 @@ export class MyUWIconLink extends HTMLElement {
     this.shadowRoot
       .getElementById("container")
       .appendChild(createIconElement(this.iconType, this.icon));
-    this.shadowRoot.getElementById("link").href = this.href;
+    this.shadowRoot.getElementById("link").href=this.href;
   }
 
   get icon() {
-    return this.getAttribute("icon") || "";
+    return this.getAttribute("icon")||"";
   }
 
   get iconType() {
-    return this.getAttribute("icon-type") || "";
+    return this.getAttribute("icon-type")||"";
   }
 
   get href() {
-    return this.getAttribute("href") || "#";
+    return this.getAttribute("href")||"#";
   }
 }
 

--- a/src/content/utils.js
+++ b/src/content/utils.js
@@ -1,12 +1,12 @@
-export const iconMap = {
+export const iconMap={
   md: {
     styleUrl: "https://fonts.googleapis.com/icon?family=Material+Icons",
     classes: "material-icons md-70",
   },
   fa: {
     styleUrl:
-      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css",
-    classes: "fa fa-70",
+      "https://use.fontawesome.com/releases/v5.1.0/css/all.css",
+    classes: "fa-70"
   },
 };
 
@@ -15,12 +15,12 @@ export const iconMap = {
  * @param {string|undefined} icon
  * @returns HTMLElement
  */
-export function createIconElement(iconType, icon = undefined) {
-  const node = document.createElement("i");
+export function createIconElement(iconType, icon=undefined) {
+  const node=document.createElement("i");
   switch (iconType) {
     case "md": {
       node.setAttribute("class", iconMap.md.classes);
-      node.innerText = icon;
+      node.innerText=icon;
       break;
     }
     case "fa": {
@@ -37,7 +37,7 @@ export function createIconElement(iconType, icon = undefined) {
  * @returns HTMLElement
  */
 export function createStyleElement(iconType) {
-  const node = document.createElement("link");
+  const node=document.createElement("link");
   node.setAttribute("rel", "stylesheet");
   node.setAttribute("href", iconMap[iconType].styleUrl);
   return node;

--- a/src/index.js
+++ b/src/index.js
@@ -11,3 +11,19 @@ export {
   MyUWCardMessage,
   MyUWIconLink,
 };
+
+// Include Font Awesome Icons
+(function () {
+  var fontAwesomeInclude=document.createElement('link');
+  fontAwesomeInclude.href='https://use.fontawesome.com/releases/v5.12.0/css/all.css';
+  fontAwesomeInclude.rel='stylesheet';
+  document.getElementsByTagName('head')[0].appendChild(fontAwesomeInclude);
+})();
+
+// Include Material Icons
+(function () {
+  var matIconsInclude=document.createElement('link');
+  matIconsInclude.href='https://fonts.googleapis.com/icon?family=Material+Icons';
+  matIconsInclude.rel='stylesheet';
+  document.getElementsByTagName('head')[0].appendChild(matIconsInclude);
+})();


### PR DESCRIPTION
**V 1.3.2**

**Updated**
- Update Font Awesome version to 5.12.0
- Minor CSS classes updates

**Fixed**
- Loading Font Awesome and Material Icons from <head> to insure their availability when application loads


Before:
<img width="909" alt="Screen Shot 2020-01-27 at 12 21 21 PM" src="https://user-images.githubusercontent.com/10341961/73205779-48317a00-4107-11ea-9ef7-22e1d3d782b3.png">

After:
<img width="906" alt="Screen Shot 2020-01-27 at 12 21 53 PM" src="https://user-images.githubusercontent.com/10341961/73205780-48317a00-4107-11ea-8ba0-154da3794f0a.png">
