### PR TITLE
Add MyUWCardMenu component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Import and include the component as follows:
 <myuw-card-frame>
   <myuw-card-header>
     Course Search and Enroll
+    <myuw-card-menu fname="course-search-and-enroll">
+      <span>Course Search and Enroll:</span> Search for courses, plan your next semester and enroll in one convenient, easy-to-use app.
+    </myuw-card-menu>
   </myuw-card-header>
   <myuw-card-content>
     <myuw-icon-link href="https://www.google.com">

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Import and include the component as follows:
   <myuw-card-header>
     Course Search and Enroll
     <myuw-card-menu fname="course-search-and-enroll">
-      <span>Course Search and Enroll:</span> Search for courses, plan your next semester and enroll in one convenient, easy-to-use app.
+      Search for courses, plan your next semester and enroll in one convenient, easy-to-use app.
     </myuw-card-menu>
   </myuw-card-header>
   <myuw-card-content>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <myuw-card-header>
       Icon Link
       <myuw-card-menu fname="icon-link">
-        <span>Icon Link:</span> Click the icon to go somewhere new.
+        Click the icon to go somewhere new.
       </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
@@ -32,7 +32,7 @@
     <myuw-card-header>
       Icon Link and Message
       <myuw-card-menu fname="icon-link-message">
-        <span>Icon Link and Message:</span> Add a personal message for your users.
+        Add a personal message for your users.
       </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
@@ -51,7 +51,7 @@
     <myuw-card-header>
       Icon Link and Warn Message
       <myuw-card-menu fname="icon-link-warn">
-        <span>Icon Link and Warn Message:</span> Draw attention to your important action.
+        Draw attention to your important action.
       </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
@@ -70,7 +70,7 @@
     <myuw-card-header>
       List of Links with Message
       <myuw-card-menu fname="link-list-message">
-        <span>List of Links with Message:</span> Mix and match for your specific needs.
+        Mix and match for your specific needs.
       </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
@@ -96,7 +96,7 @@
     <myuw-card-header>
       Multiple Link List Rows
       <myuw-card-menu fname="two-link-list">
-        <span>Multiple Link List Rows:</span> Add multiple rows for up to four buttons.
+        Add multiple rows for up to four buttons.
       </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
   <myuw-card-frame>
     <myuw-card-header>
       Icon Link
+      <myuw-card-menu fname="icon-link">
+        <span>Icon Link:</span> Click the icon to go somewhere new.
+      </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
       <myuw-icon-link href="https://www.google.com">
@@ -28,6 +31,9 @@
   <myuw-card-frame>
     <myuw-card-header>
       Icon Link and Message
+      <myuw-card-menu fname="icon-link-message">
+        <span>Icon Link and Message:</span> Add a personal message for your users.
+      </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
       <myuw-card-message>
@@ -44,6 +50,9 @@
   <myuw-card-frame>
     <myuw-card-header>
       Icon Link and Warn Message
+      <myuw-card-menu fname="icon-link-warn">
+        <span>Icon Link and Warn Message:</span> Draw attention to your important action.
+      </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
       <myuw-card-message variant="warn">
@@ -60,6 +69,9 @@
   <myuw-card-frame>
     <myuw-card-header>
       List of Links with Message
+      <myuw-card-menu fname="link-list-message">
+        <span>List of Links with Message:</span> Mix and match for your specific needs.
+      </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
       <myuw-card-message variant="warn">
@@ -83,6 +95,9 @@
   <myuw-card-frame>
     <myuw-card-header>
       Multiple Link List Rows
+      <myuw-card-menu fname="two-link-list">
+        <span>Multiple Link List Rows:</span> Add multiple rows for up to four buttons.
+      </myuw-card-menu>
     </myuw-card-header>
     <myuw-card-content>
       <myuw-link-list>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-card",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "description": "",
   "module": "dist/myuw-card.min.mjs",
   "browser": "dist/myuw-card.js",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { MyUWCardContent } from "./myuw-card-content";
 import { MyUWCardFooter } from "./myuw-card-footer";
 import { MyUWCardHeader } from "./myuw-card-header";
 import { MyUWCardFrame } from "./myuw-card-frame";
+import { MyUWCardMenu } from "./myuw-card-menu";
 import { MyUWCardMessage } from "./content/myuw-card-message";
 import { MyUWFabLink } from "./content/myuw-fab-link";
 import { MyUWIconLink } from "./content/myuw-icon-link";
@@ -12,6 +13,7 @@ export {
   MyUWCardFooter,
   MyUWCardHeader,
   MyUWCardFrame,
+  MyUWCardMenu,
   MyUWCardMessage,
   MyUWFabLink,
   MyUWIconLink,

--- a/src/myuw-card-header.js
+++ b/src/myuw-card-header.js
@@ -18,20 +18,9 @@ export class MyUWCardHeader extends HTMLElement {
             color: var(--myuw-car-font-color, #333);
             font-weight: 200;
           }
-          .more-icon {
-            position: absolute;
-            top: 5%;
-            right: 5%;
-            fill: rgba(0, 0, 0, 0.54);
-          }
         </style>
 
         <slot></slot>
-        <svg class="more-icon" width="20" height="20" role="button" tabindex=0 aria-label="more menu button">
-          <g transform="scale(0.8)">
-            <path  aria-label="more menu icon" d="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z" />
-          </g>
-        </svg>
       `;
     }
     return this._template;

--- a/src/myuw-card-menu.js
+++ b/src/myuw-card-menu.js
@@ -68,8 +68,8 @@ export class MyUWCardMenu extends HTMLElement {
             left: 0;
           }
           #more-menu.open + #menu-overlay {
-            width: 100%;
-            height: 100%;
+            width: 100vw;
+            height: 100vh;
             opacity: 0;
             z-index: 998;
             visibility: visible;
@@ -79,7 +79,7 @@ export class MyUWCardMenu extends HTMLElement {
             display: flex;
             align-items: center;
           }
-          ::slotted(span) {
+          #title {
             font-weight: bold;
           }
         </style>
@@ -90,20 +90,21 @@ export class MyUWCardMenu extends HTMLElement {
         </svg>
         <div id="more-menu">
           <div class="row">
-            <svg class="menu-icon" width="24" height="24">
+            <svg class="menu-icon" aria-label="info icon" width="24" height="24">
               <g>
-                <path d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" />
+                <path aria-label="info graphic" d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" />
               </g>
             </svg>
             <div>
+              <span id="title"></span>
               <slot></slot>
             </div>
           </div>
           <a id="details" href="#" aria-label="" role="menuitem">
             <div class="row">
-              <svg class="menu-icon" width="24" height="24">
+              <svg class="menu-icon" aria-label="details icon" width="24" height="24">
                 <g>
-                  <path d="M6.38,6H17.63L12,16L6.38,6M3,4L12,20L21,4H3Z" />
+                  <path aria-label="info graphic" d="M6.38,6H17.63L12,16L6.38,6M3,4L12,20L21,4H3Z" />
                 </g>
               </svg>
               <span>Details</span>
@@ -111,9 +112,9 @@ export class MyUWCardMenu extends HTMLElement {
           </a>
           <button id="remove" aria-label="" role="menuitem">
             <div class="row">
-              <svg class="menu-icon" width="24" height="24">
+              <svg class="menu-icon" aria-label="remove icon" width="24" height="24">
                 <g>
-                  <path d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M9,8H11V17H9V8M13,8H15V17H13V8Z" />
+                  <path aria-label="remove graphic" d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M9,8H11V17H9V8M13,8H15V17H13V8Z" />
                 </g>
               </svg>
               <span>Remove from home</span>
@@ -152,7 +153,7 @@ export class MyUWCardMenu extends HTMLElement {
    * Anchor the menu to its right side if it is not fully visibile in the viewport
    * @param {(Event|null)} event
    */
-  positionMenu(event) {
+  positionMenu() {
     const menu = this.shadowRoot.getElementById("more-menu");
     const boundingRect = menu.getBoundingClientRect();
     if (
@@ -161,10 +162,6 @@ export class MyUWCardMenu extends HTMLElement {
     ) {
       menu.style.transform = "translate(-90%, 5%)";
     }
-
-    if (event) {
-      //event.preventDefault();
-    }
   }
 
   constructor() {
@@ -172,6 +169,19 @@ export class MyUWCardMenu extends HTMLElement {
     this.attachShadow({ mode: "open" });
     this.shadowRoot.appendChild(MyUWCardMenu.template.content.cloneNode(true));
     this.shadowRoot.getElementById("details").setAttribute("href", this.href);
+
+    const title = this.parentElement.firstChild.textContent.trim();
+    this.shadowRoot.getElementById("title").textContent = `${title}: `;
+
+    this.shadowRoot
+      .getElementById("remove")
+      .setAttribute(
+        "aria-label",
+        `remove ${title} widget from your home screen`
+      );
+    this.shadowRoot
+      .getElementById("details")
+      .setAttribute("aria-label", `details about ${title}`);
   }
 
   connectedCallback() {

--- a/src/myuw-card-menu.js
+++ b/src/myuw-card-menu.js
@@ -1,0 +1,202 @@
+export class MyUWCardMenu extends HTMLElement {
+  static get elementName() {
+    return "myuw-card-menu";
+  }
+
+  static get template() {
+    if (this._template === undefined) {
+      this._template = document.createElement("template");
+      this._template.innerHTML = `
+        <style>
+          :host {
+            position: absolute;
+            top: 5%;
+            right: 5%;
+            font-size: 14px;
+            line-height: 20px;
+          }
+          a {
+            text-decoration: none;
+            color: inherit;
+          }
+          a:hover .row {
+            background-color: rgba(158, 158, 158, 0.2);
+          }
+          button {
+            background: none;
+            color: inherit;
+            border: none;
+            padding: 0;
+            margin: 0;
+            font: inherit;
+            cursor: pointer;
+            outline: inherit;
+            width: 100%;
+          }
+          button:hover .row {
+            background-color: rgba(158, 158, 158, 0.2);
+          }
+          svg {
+            fill: rgba(0, 0, 0, 0.54);
+          }
+          .menu-icon {
+            margin: 1rem;
+            flex-shrink: 0;
+          }
+          .more-icon:hover {
+            cursor: pointer;
+          }
+          #more-menu {
+            z-index: 999;
+            position: fixed;
+            transform: translate(-5%, 5%);
+            visibility: hidden;
+            background-color: #fff;
+            box-shadow: 0 2px 4px -1px rgba(0 ,0 ,0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
+            padding-top: 0.5rem;
+          }
+          #more-menu.open {
+            display: block;
+            visibility: visible;
+            min-width: 256px;
+            max-width: 290px;
+          }
+          #menu-overlay {
+            visibility: hidden;
+            position: fixed;
+            top: 0;
+            left: 0;
+          }
+          #more-menu.open + #menu-overlay {
+            width: 100%;
+            height: 100%;
+            opacity: 0;
+            z-index: 998;
+            visibility: visible;
+          }
+          .row {
+            padding-right: 1rem;
+            display: flex;
+            align-items: center;
+          }
+          ::slotted(span) {
+            font-weight: bold;
+          }
+        </style>
+        <svg id="more-icon" class="more-icon" width="20" height="20" role="button" tabindex=0 aria-label="more menu button">
+          <g transform="scale(0.8)">
+            <path aria-label="more menu icon" d="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z" />
+          </g>
+        </svg>
+        <div id="more-menu">
+          <div class="row">
+            <svg class="menu-icon" width="24" height="24">
+              <g>
+                <path d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" />
+              </g>
+            </svg>
+            <div>
+              <slot></slot>
+            </div>
+          </div>
+          <a id="details" href="#" aria-label="" role="menuitem">
+            <div class="row">
+              <svg class="menu-icon" width="24" height="24">
+                <g>
+                  <path d="M6.38,6H17.63L12,16L6.38,6M3,4L12,20L21,4H3Z" />
+                </g>
+              </svg>
+              <span>Details</span>
+            </div>
+          </a>
+          <button id="remove" aria-label="" role="menuitem">
+            <div class="row">
+              <svg class="menu-icon" width="24" height="24">
+                <g>
+                  <path d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M9,8H11V17H9V8M13,8H15V17H13V8Z" />
+                </g>
+              </svg>
+              <span>Remove from home</span>
+            </div>
+          </a>
+        </div>
+        <div id="menu-overlay"></div>
+      `;
+    }
+    return this._template;
+  }
+
+  toggleMenu() {
+    const menu = this.shadowRoot.getElementById("more-menu");
+    if (menu.classList.contains("open")) {
+      menu.classList.remove("open");
+    } else {
+      menu.classList.add("open");
+    }
+  }
+
+  /**
+   * Dispatch a custom `remove-widget` event with the widget's fname
+   */
+  removeWidgetHandler() {
+    const event = new CustomEvent("remove-widget", {
+      detail: {
+        fname: this.getAttribute("fname"),
+      },
+    });
+    this.dispatchEvent(event);
+    this.toggleMenu();
+  }
+
+  /**
+   * Anchor the menu to its right side if it is not fully visibile in the viewport
+   * @param {(Event|null)} event
+   */
+  positionMenu(event) {
+    const menu = this.shadowRoot.getElementById("more-menu");
+    const boundingRect = menu.getBoundingClientRect();
+    if (
+      boundingRect.right >= window.innerWidth ||
+      boundingRect.right >= document.documentElement.clientWidth
+    ) {
+      menu.style.transform = "translate(-90%, 5%)";
+    }
+
+    if (event) {
+      //event.preventDefault();
+    }
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot.appendChild(MyUWCardMenu.template.content.cloneNode(true));
+    this.shadowRoot.getElementById("details").setAttribute("href", this.href);
+  }
+
+  connectedCallback() {
+    this.shadowRoot
+      .getElementById("more-icon")
+      .addEventListener("click", () => {
+        this.toggleMenu(this);
+      });
+    this.shadowRoot
+      .getElementById("menu-overlay")
+      .addEventListener("click", () => {
+        this.toggleMenu(this);
+      });
+    this.shadowRoot.getElementById("remove").addEventListener("click", () => {
+      this.removeWidgetHandler(this);
+    });
+    // Position menu initially and listen to resize events to reposition
+    this.positionMenu();
+    window.addEventListener("resize", e => this.positionMenu(e));
+  }
+
+  get href() {
+    const fname = this.getAttribute("fname");
+    return fname ? `/web/apps/details/${fname}` : "#";
+  }
+}
+
+window.customElements.define(MyUWCardMenu.elementName, MyUWCardMenu);


### PR DESCRIPTION
This PR adds a MyUWCardMenu component to act as the "more" (shish kebab) menu.

Basic show/hide:

![menu-show-hide](https://user-images.githubusercontent.com/1573349/74047007-408a9480-4995-11ea-97ae-bc1f466056a9.gif)

The menu will be re-positioned if it does not fit in the viewport:

![menu-reposition](https://user-images.githubusercontent.com/1573349/74047060-58faaf00-4995-11ea-8f8e-d2e6ae6b1ee1.gif)

The "Remove" button fires a custom `remove-widget` event and passes the widget's `fname` in the `details` object.

There will need to be some accessibility tweaks but I wanted to get this PR out there.